### PR TITLE
Move lower bound IDE range to 211

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.0.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 203
+pluginSinceBuild = 211
 pluginUntilBuild = 213.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties


### PR DESCRIPTION
It appears that due to the use of `SlowOperations` this plugin is not compatible with v203 of IntelliJ Ultimate:
![image](https://user-images.githubusercontent.com/15261525/148433858-75ade058-b8f7-4021-8c5b-f3cafecb4d93.png)

I don't think we need to support v203, though we can always investigate some kind of backwards compatibility solution later on if need be (I reached out to JetBrains to ask what this would be but haven't heard back yet).

For now, I am changing the lower bound of support to 211 to get this thing approved for the JetBrains Marketplace.