### PR TITLE
Bump to 1.0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.ragurney.spotless
 pluginName = Spotless Gradle
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.1
+pluginVersion = 1.0.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.


### PR DESCRIPTION
We need to bump to 1.0.2 to release new plugin with lower bound supported IDE to 211