### PR TITLE
Add GitHub Link and `--no-configuration-cache` to `spotlessApply` Executino

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ from within the IDE on the current file selected in the editor.
 You may find the spotless action via <kbd>Code</kbd> > <kbd>Reformat Code with Spotless</kbd>.
 
 ![spotlessdemo](https://user-images.githubusercontent.com/15261525/147841908-d5cc3bda-56c8-4cbd-ba29-13ebe29f6a1d.gif)
+
+Report bugs or contribute enhancements on GitHub [(ragurney/spotless-intellij-gradle)](https://github.com/ragurney/spotless-intellij-gradle)
 <!-- Plugin description end -->
 
 ## Features

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.ragurney.spotless
 pluginName = Spotless Gradle
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.2
+pluginVersion = 1.0.3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatCodeProcessor.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatCodeProcessor.java
@@ -76,8 +76,8 @@ public class ReformatCodeProcessor extends AbstractLayoutCodeProcessor {
       ExternalSystemTaskExecutionSettings settings = constructTaskExecutionSettings(fileToProcess);
 
       // Execute gradle task
-      ExternalSystemUtil.runTask(settings, DefaultRunExecutor.EXECUTOR_ID, myProject, GradleConstants.SYSTEM_ID,
-          null, ProgressExecutionMode.IN_BACKGROUND_ASYNC, false);
+      ExternalSystemUtil.runTask(settings, DefaultRunExecutor.EXECUTOR_ID, myProject, GradleConstants.SYSTEM_ID, null,
+          ProgressExecutionMode.IN_BACKGROUND_ASYNC, false);
     }));
   }
 
@@ -95,7 +95,8 @@ public class ReformatCodeProcessor extends AbstractLayoutCodeProcessor {
     ExternalSystemTaskExecutionSettings settings = new ExternalSystemTaskExecutionSettings();
     settings.setExternalProjectPath(myProject.getBasePath());
     settings.setTaskNames(List.of("spotlessApply"));
-    settings.setScriptParameters(String.format("-PspotlessIdeHook=\"%s\"", fileToProcess.getVirtualFile().getPath()));
+    settings.setScriptParameters(
+        String.format("-PspotlessIdeHook=\"%s\" --no-configuration-cache", fileToProcess.getVirtualFile().getPath()));
     settings.setVmOptions("");
     settings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.getId());
     return settings;


### PR DESCRIPTION
This adds a GitHub link to the plugin description section, as well as the `--no-configuration-cache` option to the gradle task 
execution to avoid the issue outlined by @nedtwigg in https://github.com/ragurney/spotless-intellij-gradle/issues/18.

Resolves #17, Resolves #18;