### PR TITLE
Adding support for IntelliJ Platform 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,15 +9,15 @@ pluginVersion = 1.0.7
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2021.1.2
+platformVersion = 2022.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.gradle:211.7442.57
+platformPlugins = com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.ragurney.spotless
 pluginName = Spotless Gradle
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.7
+pluginVersion = 1.1.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.


### PR DESCRIPTION
Hello!

v1.0.7 of `spotless-intellij-gradle` doesn't support the latest release of IntelliJ (2022.2). This should enable compatibility. I've been running into some issues regarding the `:buildSearchableOptions` task.

```shell
> Task :buildSearchableOptions FAILED
[gradle-intellij-plugin :spotless:buildSearchableOptions] Cannot resolve runtime with ideDir='/Users/yoo/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2022.2/42c296374014a649785bb84aa6d8dc2d18f2ca0e/ideaIC-2022.2'
[gradle-intellij-plugin :spotless:buildSearchableOptions] Cannot find java executable in: /Users/yoo/.gradle/caches/modules-2/files-2.1/com.jetbrains/jbre/jbr-17.0.3-osx-aarch64-b469.32/extracted
[gradle-intellij-plugin :spotless:buildSearchableOptions] Cannot resolve runtime with ideDir='/Users/yoo/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2022.2/42c296374014a649785bb84aa6d8dc2d18f2ca0e/ideaIC-2022.2', version='17.0.3b469.32'
[gradle-intellij-plugin :spotless:buildSearchableOptions] Cannot resolve runtime with ideDir='/Users/yoo/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2022.2/42c296374014a649785bb84aa6d8dc2d18f2ca0e/ideaIC-2022.2'

Start Failed
!bootstrap.error.message.internal.error.please.refer.to.0!https://jb.gg/ide/critical-startup-errors!

java.lang.NoClassDefFoundError: com/intellij/openapi/util/SystemInfoRt
	at com.intellij.openapi.application.PathManager.getBinDirectories(PathManager.java:175)
	at com.intellij.openapi.application.PathManager.isIdeaHome(PathManager.java:163)
	at com.intellij.openapi.application.PathManager.getHomeDirFor(PathManager.java:156)
	at com.intellij.openapi.application.PathManager.getHomePathFor(PathManager.java:146)
	at com.intellij.openapi.application.PathManager.getHomePath(PathManager.java:95)
	at com.intellij.openapi.application.PathManager.loadProperties(PathManager.java:540)
	at com.intellij.idea.Main.bootstrap(Main.java:91)
	at com.intellij.idea.Main.main(Main.java:81)
Caused by: java.lang.ClassNotFoundException: com.intellij.openapi.util.SystemInfoRt
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 8 more

-----
!bootstrap.error.message.jre.details!17.0.3+7-b469.32 aarch64 (JetBrains s.r.o.)
/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home!

Caused by: java.lang.ClassNotFoundException: com.intellij.openapi.util.SystemInfoRt

Execution failed for task ':buildSearchableOptions'.
> Process 'command '/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java'' finished with non-zero exit value 3

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```

Updating  `org.jetbrains.intellij` to `1.5.2` (latest) in `build.gradle.kts` gets rid of this error, but also introduces another errr in the form of a linking error for a `Main` class

