### PR TITLE
Add action to reformat all files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.10.0"
+    id("org.jetbrains.intellij") version "1.12.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.ragurney.spotless
 pluginName = Spotless Gradle
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.10
+pluginVersion = 1.1.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.ragurney.spotless
 pluginName = Spotless Gradle
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.0
+pluginVersion = 2.0.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatAllFilesAction.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatAllFilesAction.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 
 
 /**
- * The action which is called on "Reformat All Files."
+ * The action which is called on "Reformat All Files With Spotless".
  */
-public class ReformatProjectAction extends AnAction {
+public class ReformatAllFilesAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatCodeProcessor.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatCodeProcessor.java
@@ -38,9 +38,15 @@ import org.jetbrains.plugins.gradle.util.GradleConstants;
 public class ReformatCodeProcessor extends AbstractLayoutCodeProcessor {
   private static final Logger LOG = Logger.getInstance(ReformatCodeProcessor.class);
   private static final Version NO_CONFIG_CACHE_MIN_GRADLE_VERSION = new Version(6, 6, 0);
+  private boolean isReformatAllEnabled = false;
 
   public ReformatCodeProcessor(@NotNull PsiFile file) {
     super(file.getProject(), file, getProgressText(), getCommandName(), true);
+  }
+
+  public ReformatCodeProcessor(@NotNull PsiFile file, boolean reformatAll) {
+    super(file.getProject(), file, getProgressText(), getCommandName(), true);
+    this.isReformatAllEnabled = reformatAll;
   }
 
   @Override
@@ -104,8 +110,10 @@ public class ReformatCodeProcessor extends AbstractLayoutCodeProcessor {
     ExternalSystemTaskExecutionSettings settings = new ExternalSystemTaskExecutionSettings();
     settings.setExternalProjectPath(myProject.getBasePath());
     settings.setTaskNames(List.of("spotlessApply"));
-    settings.setScriptParameters(
-        String.format("-PspotlessIdeHook=\"%s\"%s", fileToProcess.getVirtualFile().getPath(), noConfigCacheOption));
+    if (!isReformatAllEnabled) {
+      settings.setScriptParameters(
+          String.format("-PspotlessIdeHook=\"%s\"%s", fileToProcess.getVirtualFile().getPath(), noConfigCacheOption));
+    }
     settings.setVmOptions("");
     settings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.getId());
     return settings;

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatFileAction.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatFileAction.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 
 /**
- * The action which is called on "Reformat Current File."
+ * The action which is called on "Reformat File With Spotless".
  */
 public class ReformatFileAction extends AnAction {
   private static final Logger LOG = Logger.getInstance(ReformatFileAction.class);

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatFileAction.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatFileAction.java
@@ -1,0 +1,44 @@
+package com.github.ragurney.spotless.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * The action which is called on "Reformat Current File."
+ */
+public class ReformatFileAction extends AnAction {
+  private static final Logger LOG = Logger.getInstance(ReformatFileAction.class);
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+    DataContext dataContext = event.getDataContext();
+
+    final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
+    if (project == null) {
+      return;
+    }
+    final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
+
+    PsiFile file;
+
+    if (editor != null) {
+      file = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
+
+      if (file == null) {
+        return;
+      }
+
+      new ReformatCodeProcessor(file).run();
+    }
+  }
+}

--- a/src/main/java/com/github/ragurney/spotless/actions/ReformatProjectAction.java
+++ b/src/main/java/com/github/ragurney/spotless/actions/ReformatProjectAction.java
@@ -4,41 +4,33 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
-import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 
 /**
- * The action which is called on "Reformat Code with Spotless."
+ * The action which is called on "Reformat All Files."
  */
-public class ReformatCodeAction extends AnAction {
-  private static final Logger LOG = Logger.getInstance(ReformatCodeAction.class);
+public class ReformatProjectAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
     DataContext dataContext = event.getDataContext();
+    event.getData(CommonDataKeys.PSI_FILE);
 
     final Project project = CommonDataKeys.PROJECT.getData(dataContext);
-
     if (project == null) {
       return;
     }
+
     final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
-
-    PsiFile file;
-
     if (editor != null) {
-      file = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
-
-      if (file == null) {
-        return;
-      }
-
-      new ReformatCodeProcessor(file).run();
+      Optional.ofNullable(PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument()))
+          .ifPresent(file -> new ReformatCodeProcessor(file, true).run());
     }
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,11 +8,17 @@
     <depends>com.intellij.gradle</depends>
 
     <actions>
-        <action id="com.github.ragurney.spotless.actions.ReformatCodeAction"
-                class="com.github.ragurney.spotless.actions.ReformatCodeAction" text="Reformat Code with Spotless"
-                icon="SpotlessIcons.SPOTLESS_DEFAULT_ICON"
-                description="Reformats code with Spotless">
+        <group id="com.github.ragurney.spotless.actions.ReformatActions"
+               text="Reformat with Spotless"
+               popup="true"
+               icon="SpotlessIcons.SPOTLESS_DEFAULT_ICON">
+            <action id="com.github.ragurney.spotless.actions.ReformatFileAction"
+                    class="com.github.ragurney.spotless.actions.ReformatFileAction" text="Reformat Current File"
+                    description="Reformats current file with Spotless"/>
+            <action id="com.github.ragurney.spotless.actions.ReformatProjectAction"
+                    class="com.github.ragurney.spotless.actions.ReformatProjectAction" text="Reformat All Files"
+                    description="Reformats all files with Spotless"/>
             <add-to-group group-id="CodeFormatGroup" relative-to-action="ReformatCode" anchor="before"/>
-        </action>
+        </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,17 +8,17 @@
     <depends>com.intellij.gradle</depends>
 
     <actions>
-        <group id="com.github.ragurney.spotless.actions.ReformatActions"
-               text="Reformat with Spotless"
-               popup="true"
-               icon="SpotlessIcons.SPOTLESS_DEFAULT_ICON">
-            <action id="com.github.ragurney.spotless.actions.ReformatFileAction"
-                    class="com.github.ragurney.spotless.actions.ReformatFileAction" text="Reformat Current File"
-                    description="Reformats current file with Spotless"/>
-            <action id="com.github.ragurney.spotless.actions.ReformatProjectAction"
-                    class="com.github.ragurney.spotless.actions.ReformatProjectAction" text="Reformat All Files"
-                    description="Reformats all files with Spotless"/>
+        <action id="com.github.ragurney.spotless.actions.ReformatFileAction"
+                class="com.github.ragurney.spotless.actions.ReformatFileAction" text="Reformat File With Spotless"
+                icon="SpotlessIcons.SPOTLESS_DEFAULT_ICON"
+                description="Reformats current file with Spotless">
             <add-to-group group-id="CodeFormatGroup" relative-to-action="ReformatCode" anchor="before"/>
-        </group>
+        </action>
+        <action id="com.github.ragurney.spotless.actions.ReformatAllFilesAction"
+                class="com.github.ragurney.spotless.actions.ReformatAllFilesAction" text="Reformat All Files With Spotless"
+                icon="SpotlessIcons.SPOTLESS_DEFAULT_ICON"
+                description="Reformats all files with Spotless">
+            <add-to-group group-id="CodeFormatGroup" relative-to-action="ReformatCode" anchor="before" />
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
Implements #46 

Running the plugin with `Reformat with Spotless -> Reformat All Files` reformats all files according to the `spotless` configuration. I've renamed the existing action to be more consistent with what it does and moved both actions into a `Reformat with Spotless` group, in order to not clutter the UI too much. 

This can easily be reverted back, and `Reformat All Files` added separately in the UI, if you prefer it that  way. I've also upgraded the gradle intellij plugin from `1.10.0` to `1.12.0`, because otherwise I wasn't able to run `./gradlew runIde`.

I'll update the README as well, once we clear any comments you might have on the PR.